### PR TITLE
Fix node crashing when using --use_strict flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function dev(opts) {
   return function *logger(next) {
     // request
     var start = new Date;
-    console.log('  \033[90m<-- \033[;1m%s\033[0;90m %s\033[0m', this.method, this.url);
+    console.log('  \x1B[90m<-- \x1B[;1m%s\x1B[0;90m %s\x1B[0m', this.method, this.url);
 
     try {
       yield next;
@@ -103,11 +103,11 @@ function log(ctx, start, len, err, event) {
     length = bytes(len);
   }
 
-  var upstream = err ? '\033[31mxxx'
-    : event === 'close' ? '\033[33m-x-'
-    : '\033[90m-->';
+  var upstream = err ? '\x1B[31mxxx'
+    : event === 'close' ? '\x1B[33m-x-'
+    : '\x1B[90m-->';
 
-  console.log('  ' + upstream + ' \033[;1m%s\033[0;90m %s \033[' + c + 'm%s\033[90m %s %s\033[0m',
+  console.log('  ' + upstream + ' \x1B[;1m%s\x1B[0;90m %s \x1B[' + c + 'm%s\x1B[90m %s %s\x1B[0m',
     ctx.method,
     ctx.originalUrl,
     status,


### PR DESCRIPTION
Without this, when using node with --use_strict, the following error occurs:

SyntaxError: Octal literals are not allowed in strict mode.

--use_strict flag is very useful while in development/prototyping, so as this logger is intended for development, this is a rational update.
