### PR TITLE
Follow up PR #20

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function dev(opts) {
     res.once('finish', onfinish);
     res.once('close', onclose);
 
-    function done(event){
+    var done = function done(event) {
       res.removeListener('finish', onfinish);
       res.removeListener('close', onclose);
       log(ctx, start, counter ? counter.length : length, null, event);


### PR DESCRIPTION
In strict mode, fails with the following:

```
SyntaxError: In strict mode code, functions can only be declared at top level or immediately
within another function.
```

This patch prevents this SyntaxError from being thrown.

This is a follow-up for PR #20 
