### PR TITLE
Add the ability to use a custom reporter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,19 @@ var app = koa()
 app.use(logger())
 ```
 
+## Custom Reporter
+
+If you want to log to another reporter, simply pass it as an argument.
+
+```js
+var logger = require('koa-logger')
+var koa = require('koa')
+var mag = require('mag')
+
+var app = koa()
+app.use(logger({reporter: mag('koa')}))
+```
+
 ## Notes
 
   Recommended that you `.use()` this middleware near the top

--- a/index.js
+++ b/index.js
@@ -35,16 +35,24 @@ var colors = {
  */
 
 function dev(opts) {
+  if ('object' !== typeof opts) {
+    opts = {};
+  }
+
+  if ('object' !== typeof opts.reporter) {
+    opts.reporter = console;
+  }
+
   return function *logger(next) {
     // request
     var start = new Date;
-    console.log('  \x1B[90m<-- \x1B[;1m%s\x1B[0;90m %s\x1B[0m', this.method, this.url);
+    opts.reporter.log('  \x1B[90m<-- \x1B[;1m%s\x1B[0;90m %s\x1B[0m', this.method, this.url);
 
     try {
       yield next;
     } catch (err) {
       // log uncaught downstream errors
-      log(this, start, null, err);
+      log(this, opts, start, null, err);
       throw err;
     }
 
@@ -74,7 +82,7 @@ function dev(opts) {
     function done(event){
       res.removeListener('finish', onfinish);
       res.removeListener('close', onclose);
-      log(ctx, start, counter ? counter.length : length, null, event);
+      log(ctx, opts, start, counter ? counter.length : length, null, event);
     }
   }
 }
@@ -83,7 +91,7 @@ function dev(opts) {
  * Log helper.
  */
 
-function log(ctx, start, len, err, event) {
+function log(ctx, opts, start, len, err, event) {
   // get the status code of the response
   var status = err
     ? (err.status || 500)
@@ -107,7 +115,7 @@ function log(ctx, start, len, err, event) {
     : event === 'close' ? '\x1B[33m-x-'
     : '\x1B[90m-->';
 
-  console.log('  ' + upstream + ' \x1B[;1m%s\x1B[0;90m %s \x1B[' + c + 'm%s\x1B[90m %s %s\x1B[0m',
+  opts.reporter.log('  ' + upstream + ' \x1B[;1m%s\x1B[0;90m %s \x1B[' + c + 'm%s\x1B[90m %s %s\x1B[0m',
     ctx.method,
     ctx.originalUrl,
     status,


### PR DESCRIPTION
This PR allows the user of koa-logger to tie it into their existing logging infrastructure.

Before:
![screenshot from 2015-02-01 02 14 21](https://cloud.githubusercontent.com/assets/53233/5999409/d78389ea-aad1-11e4-9628-a02a7d3c0b37.png)

After:
![screenshot from 2015-02-01 02 24 11](https://cloud.githubusercontent.com/assets/53233/5999411/de07f792-aad1-11e4-85f3-a820f17b373c.png)