### PR TITLE
replace cumbersome TTY colors, simplify numbering scheme

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,9 +1,18 @@
 
+1.3.0 / 2015-03-27
+==================
+
+ * fix: use `this.response.length` instead of `this.responseLength`
+ * add: unitex
+ * add: colors
+ * remove: humanize-number
+ * remove: bytes
+
 1.2.2 / 2014-07-05
 ==================
 
  * fix: stop using octal literals for strict mode
- 
+
 1.2.1 / 2014-05-13
 ==================
 

--- a/Readme.md
+++ b/Readme.md
@@ -4,14 +4,14 @@
 Development style logger middleware for koa.
 
 ```
-=> GET /
-<= 200 835 ms 746 B
-=> GET /
-<= 200 960ms 1.9 KB
-=> GET /users
-<= 200 357ms 922 B
-=> GET /users?page=2
-<= 200 466 ms 4.66 KB
+<-- GET /
+--> 200 835 ms 746 B
+<-- GET /
+--> 200 960ms 1.9 KB
+<-- GET /users
+--> 200 357ms 922 B
+<-- GET /users?page=2
+--> 200 466 ms 4.66 KB
 ```
 
 ## Installation

--- a/Readme.md
+++ b/Readme.md
@@ -1,17 +1,17 @@
 
 # koa-logger
 
- Development style logger middleware for koa.
+Development style logger middleware for koa.
 
 ```
-<-- GET /
---> GET / 200 835ms 746b
-<-- GET /
---> GET / 200 960ms 1.9kb
-<-- GET /users
---> GET /users 200 357ms 922b
-<-- GET /users?page=2
---> GET /users?page=2 200 466ms 4.66kb
+=> GET /
+<= 200 835 ms 746 B
+=> GET /
+<= 200 960ms 1.9 KB
+=> GET /users
+<= 200 357ms 922 B
+=> GET /users?page=2
+<= 200 466 ms 4.66 KB
 ```
 
 ## Installation
@@ -37,4 +37,4 @@ app.use(logger())
 
 ## License
 
-  MIT
+MIT

--- a/example.js
+++ b/example.js
@@ -7,6 +7,8 @@ var app = koa();
 // wrap subsequent middleware in a logger
 
 app.use(logger());
+// app.use(logger({ lean: true, reverse: true }));
+
 
 // 204
 

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function dev(opts) {
  * Log helper.
  */
 
-var datafmt = unit.formatter({ unit: 'B', base: 1024 });
+var datafmt = unit.formatter({ unit: 'B', base: 1024, atomic: true });
 
 function log(ctx, start, len, err, event) {
   // get the status code of the response

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function dev(opts) {
     // calculate the length of a streaming response
     // by intercepting the stream with a counter.
     // only necessary if a content-length header is currently not set.
-    var length = this.responseLength;
+    var length = this.response.length;
     var body = this.body;
     var counter;
     if (null == length && body && body.readable) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "colors": "^1.0.3",
     "passthrough-counter": "^1.0.0",
-    "unitex": "^0.1.2"
+    "unitex": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "koa-logger",
   "description": "Logging middleware for koa",
   "repository": "koajs/logger",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "keywords": [
     "koa",
     "middleware",
@@ -18,8 +18,8 @@
   },
   "license": "MIT",
   "dependencies": {
+    "colors": "^1.0.3",
     "passthrough-counter": "^1.0.0",
-    "humanize-number": "~0.0.1",
-    "bytes": "1"
+    "unitex": "^0.1.2"
   }
 }


### PR DESCRIPTION
I simplified the coloring scheme for the logging, as I found it to be pretty unmaintainable. This way it also keeps us using the 8-color scheme, so we can support all terminals.

I also found the arrows to be somewhat unintuitive, because an incoming request should point inward, and an outcoming request should point outward, so I switched them. It also seemed redundant to repeat the request/url, so I removed that.

Lastly, I wrote a new package that basically handles unit formatting, which replaces both the humanization and bytes packages. 

Here's an example of the new version at work with `example.js`:
![example.js](http://i.imgur.com/0EC9uu3.png)

Running on a server:
![React Server](http://i.imgur.com/aPdsSjU.png)

This should also fix #26.