### PR TITLE
Fix content length detect

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function dev(opts) {
     // calculate the length of a streaming response
     // by intercepting the stream with a counter.
     // only necessary if a content-length header is currently not set.
-    var length = this.responseLength;
+    var length = this.response.length;
     var body = this.body;
     var counter;
     if (null == length && body && body.readable) {


### PR DESCRIPTION
Failing to detect length here cause koa to return a response without content-length when the `this.body` is a stream (for example, when serving file with `koa-sendfile`).

This is because `this.body = stream` [should reset](https://github.com/koajs/koa/blob/286f5ad43eef36ea4534eebc17bfb6b19712f07a/test/response/length.js#L52) `this.length`, running the counter does exactly that.