### PR TITLE
Refactor output coloring and add test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "0.12"
+  - "iojs"
+before_install: npm install -g npm
+script: npm test

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,9 @@
 
 # koa-logger
 
+[![npm version][npm-image]][npm-url]
+[![build status][travis-image]][travis-url]
+
  Development style logger middleware for koa.
 
 ```
@@ -38,3 +41,8 @@ app.use(logger())
 ## License
 
   MIT
+
+[npm-image]: https://img.shields.io/npm/v/koa-logger.svg?style=flat-square
+[npm-url]: https://www.npmjs.com/package/koa-logger
+[travis-image]: https://img.shields.io/travis/koajs/logger.svg?style=flat-square
+[travis-url]: https://travis-ci.org/koajs/logger

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 var Counter = require('passthrough-counter');
 var humanize = require('humanize-number');
 var bytes = require('bytes');
+var chalk = require('chalk');
 
 /**
  * TTY check for dev format.
@@ -22,12 +23,12 @@ module.exports = dev;
  * Color map.
  */
 
-var colors = {
-  5: 31,
-  4: 33,
-  3: 36,
-  2: 32,
-  1: 32
+var colorCodes = {
+  5: 'red',
+  4: 'yellow',
+  3: 'cyan',
+  2: 'green',
+  1: 'green'
 };
 
 /**
@@ -38,7 +39,11 @@ function dev(opts) {
   return function *logger(next) {
     // request
     var start = new Date;
-    console.log('  \x1B[90m<-- \x1B[;1m%s\x1B[0;90m %s\x1B[0m', this.method, this.url);
+    console.log('  ' + chalk.gray('<--')
+      + ' ' + chalk.bold('%s')
+      + ' ' + chalk.gray('%s'),
+        this.method,
+        this.originalUrl);
 
     try {
       yield next;
@@ -91,7 +96,7 @@ function log(ctx, start, len, err, event) {
 
   // set the color of the status code;
   var s = status / 100 | 0;
-  var c = colors[s];
+  var color = colorCodes[s];
 
   // get the human readable response length
   var length;
@@ -103,16 +108,21 @@ function log(ctx, start, len, err, event) {
     length = bytes(len);
   }
 
-  var upstream = err ? '\x1B[31mxxx'
-    : event === 'close' ? '\x1B[33m-x-'
-    : '\x1B[90m-->';
+  var upstream = err ? chalk.red('xxx')
+    : event === 'close' ? chalk.yellow('-x-')
+    : chalk.gray('-->')
 
-  console.log('  ' + upstream + ' \x1B[;1m%s\x1B[0;90m %s \x1B[' + c + 'm%s\x1B[90m %s %s\x1B[0m',
-    ctx.method,
-    ctx.originalUrl,
-    status,
-    time(start),
-    length);
+  console.log('  ' + upstream
+    + ' ' + chalk.bold('%s')
+    + ' ' + chalk.gray('%s')
+    + ' ' + chalk[color]('%s')
+    + ' ' + chalk.gray('%s')
+    + ' ' + chalk.gray('%s'),
+      ctx.method,
+      ctx.originalUrl,
+      status,
+      time(start),
+      length);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,14 +12,23 @@
   "files": [
     "index.js"
   ],
+  "scripts": {
+    "test": "mocha test.js"
+  },
   "devDependencies": {
-    "koa": "*",
-    "koa-compress": "*"
+    "chai": "^2.3.0",
+    "koa": "^0.21.0",
+    "koa-route": "^2.4.1",
+    "mocha": "^2.2.5",
+    "sinon": "^1.14.1",
+    "sinon-chai": "^2.7.0",
+    "supertest": "^1.0.1"
   },
   "license": "MIT",
   "dependencies": {
-    "passthrough-counter": "^1.0.0",
+    "bytes": "1",
+    "chalk": "^1.0.0",
     "humanize-number": "~0.0.1",
-    "bytes": "1"
+    "passthrough-counter": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "mocha test.js"
+    "test": "mocha --harmony test.js"
   },
   "devDependencies": {
     "chai": "^2.3.0",

--- a/test-server.js
+++ b/test-server.js
@@ -1,0 +1,39 @@
+
+/**
+ * test server
+ */
+
+var koa = require('koa');
+var _ = require('koa-route');
+var logger = require('./index');
+
+var app = koa();
+app.use(logger());
+
+app.use(_.get('/200', function *() {
+  this.body = 'hello world';
+}));
+
+app.use(_.get('/301', function *() {
+  this.status = 301;
+}));
+
+app.use(_.get('/304', function *() {
+  this.status = 304;
+}));
+
+app.use(_.get('/404', function *() {
+  this.status = 404;
+  this.body = 'not found';
+}));
+
+app.use(_.get('/500', function *() {
+  this.status = 500;
+  this.body = 'server error';
+}));
+
+app.use(_.get('/error', function *() {
+  throw new Error('oh no');
+}));
+
+module.exports = app;

--- a/test.js
+++ b/test.js
@@ -1,0 +1,155 @@
+
+/**
+ * test cases
+ */
+
+// test tools
+var chai = require('chai');
+var sinon = require('sinon');
+var sc = require('sinon-chai');
+var request = require('supertest');
+chai.use(sc);
+var expect = chai.expect;
+
+// test subjects
+var chalk = require('chalk');
+var app = require('./test-server');
+var log, sandbox;
+
+describe('koa-logger', function() {
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+    log = sandbox.spy(console, 'log');
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  it('should log a request', function(done) {
+    request(app.listen()).get('/200').expect(200, 'hello world', function() {
+      expect(log).to.have.been.called;
+      done();
+    });
+  });
+
+  it('should log a request with correct method and url', function(done) {
+    request(app.listen()).head('/200').expect(200, function() {
+      expect(log).to.have.been.calledWith('  ' + chalk.gray('<--')
+        + ' ' + chalk.bold('%s')
+        + ' ' + chalk.gray('%s'),
+          'HEAD',
+          '/200');
+      done();
+    });
+  });
+
+  it('should log a response', function(done) {
+    request(app.listen()).get('/200').expect(200, function() {
+      expect(log).to.have.been.calledTwice;
+      done();
+    });
+  });
+
+  it('should log a 200 response', function(done) {
+    request(app.listen()).get('/200').expect(200, function() {
+      expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
+        + ' ' + chalk.bold('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.green('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.gray('%s'),
+          'GET',
+          '/200',
+          200,
+          sinon.match.any,
+          '11b');
+      done();
+    });
+  });
+
+  it('should log a 301 response', function(done) {
+    request(app.listen()).get('/301').expect(301, function() {
+      expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
+        + ' ' + chalk.bold('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.cyan('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.gray('%s'),
+          'GET',
+          '/301',
+          301,
+          sinon.match.any,
+          '-');
+      done();
+    });
+  });
+
+  it('should log a 304 response', function(done) {
+    request(app.listen()).get('/304').expect(304, function() {
+      expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
+        + ' ' + chalk.bold('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.cyan('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.gray('%s'),
+          'GET',
+          '/304',
+          304,
+          sinon.match.any,
+          '');
+      done();
+    });
+  });
+
+  it('should log a 404 response', function(done) {
+    request(app.listen()).get('/404').expect(404, function() {
+      expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
+        + ' ' + chalk.bold('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.yellow('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.gray('%s'),
+          'GET',
+          '/404',
+          404,
+          sinon.match.any,
+          '9b');
+      done();
+    });
+  });
+
+  it('should log a 500 response', function(done) {
+    request(app.listen()).get('/500').expect(500, function() {
+      expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
+        + ' ' + chalk.bold('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.red('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.gray('%s'),
+          'GET',
+          '/500',
+          500,
+          sinon.match.any,
+          '12b');
+      done();
+    });
+  });
+
+  it('should log middleware error', function(done) {
+    request(app.listen()).get('/error').expect(500, function() {
+      expect(log).to.have.been.calledWith('  ' + chalk.red('xxx')
+        + ' ' + chalk.bold('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.red('%s')
+        + ' ' + chalk.gray('%s')
+        + ' ' + chalk.gray('%s'),
+          'GET',
+          '/error',
+          500,
+          sinon.match.any,
+          '-');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
- use `chalk` to make the coloring easier to debug. 
- added test cases to cover some basic usage.

probably should add travis integration as well.