### PR TITLE
Add support for output without ansi color information

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,9 +33,18 @@ var colorCodes = {
 
 /**
  * Development logger.
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.disableColor]
  */
 
 function dev(opts) {
+  opts = opts || {};
+
+  if (opts.disableColor) {
+    chalk = new chalk.constructor({enabled: false});
+  }
+
   return function *logger(next) {
     // request
     var start = new Date;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "koa-logger",
   "description": "Logging middleware for koa",
   "repository": "koajs/logger",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "keywords": [
     "koa",
     "middleware",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "koa-logger",
   "description": "Logging middleware for koa",
   "repository": "koajs/logger",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "keywords": [
     "koa",
     "middleware",
@@ -22,6 +22,7 @@
     "mocha": "^2.2.5",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
+    "strip-ansi": "^3.0.1",
     "supertest": "^1.0.1"
   },
   "license": "MIT",

--- a/test-server.js
+++ b/test-server.js
@@ -5,35 +5,35 @@
 
 var koa = require('koa');
 var _ = require('koa-route');
-var logger = require('./index');
 
 var app = koa();
-app.use(logger());
 
-app.use(_.get('/200', function *() {
-  this.body = 'hello world';
-}));
+app.init = function() {
+  app.use(_.get('/200', function *() {
+    this.body = 'hello world';
+  }));
 
-app.use(_.get('/301', function *() {
-  this.status = 301;
-}));
+  app.use(_.get('/301', function *() {
+    this.status = 301;
+  }));
 
-app.use(_.get('/304', function *() {
-  this.status = 304;
-}));
+  app.use(_.get('/304', function *() {
+    this.status = 304;
+  }));
 
-app.use(_.get('/404', function *() {
-  this.status = 404;
-  this.body = 'not found';
-}));
+  app.use(_.get('/404', function *() {
+    this.status = 404;
+    this.body = 'not found';
+  }));
 
-app.use(_.get('/500', function *() {
-  this.status = 500;
-  this.body = 'server error';
-}));
+  app.use(_.get('/500', function *() {
+    this.status = 500;
+    this.body = 'server error';
+  }));
 
-app.use(_.get('/error', function *() {
-  throw new Error('oh no');
-}));
+  app.use(_.get('/error', function *() {
+    throw new Error('oh no');
+  }));
+};
 
 module.exports = app;

--- a/test.js
+++ b/test.js
@@ -1,4 +1,3 @@
-
 /**
  * test cases
  */
@@ -8,148 +7,188 @@ var chai = require('chai');
 var sinon = require('sinon');
 var sc = require('sinon-chai');
 var request = require('supertest');
+var logger = require('./index');
+var stripAnsi = require('strip-ansi');
 chai.use(sc);
 var expect = chai.expect;
 
 // test subjects
 var chalk = require('chalk');
-var app = require('./test-server');
-var log, sandbox;
+var app,
+  log,
+  sandbox;
 
 describe('koa-logger', function() {
-  beforeEach(function() {
-    sandbox = sinon.sandbox.create();
-    log = sandbox.spy(console, 'log');
-  });
 
-  afterEach(function() {
-    sandbox.restore();
-  });
+  describe('request logging', function() {
+    before(function() {
+      app = require('./test-server');
+      app.use(logger());
+      app.init();
+    });
 
-  it('should log a request', function(done) {
-    request(app.listen()).get('/200').expect(200, 'hello world', function() {
-      expect(log).to.have.been.called;
-      done();
+    beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+      log = sandbox.spy(console, 'log');
+    });
+
+    afterEach(function() {
+      sandbox.restore();
+    });
+
+    it('should log a request', function(done) {
+      request(app.listen()).get('/200').expect(200, 'hello world', function() {
+        expect(log).to.have.been.called;
+        done();
+      });
+    });
+
+    it('should log a request with correct method and url', function(done) {
+      request(app.listen()).head('/200').expect(200, function() {
+        expect(log).to.have.been.calledWith('  ' + chalk.gray('<--')
+          + ' ' + chalk.bold('%s')
+          + ' ' + chalk.gray('%s'),
+            'HEAD',
+            '/200');
+        done();
+      });
+    });
+
+    it('should log a response', function(done) {
+      request(app.listen()).get('/200').expect(200, function() {
+        expect(log).to.have.been.calledTwice;
+        done();
+      });
+    });
+
+    it('should log a 200 response', function(done) {
+      request(app.listen()).get('/200').expect(200, function() {
+        expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
+          + ' ' + chalk.bold('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.green('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.gray('%s'),
+            'GET',
+            '/200',
+            200,
+            sinon.match.any,
+            '11b');
+        done();
+      });
+    });
+
+    it('should log a 301 response', function(done) {
+      request(app.listen()).get('/301').expect(301, function() {
+        expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
+          + ' ' + chalk.bold('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.cyan('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.gray('%s'),
+            'GET',
+            '/301',
+            301,
+            sinon.match.any,
+            '-');
+        done();
+      });
+    });
+
+    it('should log a 304 response', function(done) {
+      request(app.listen()).get('/304').expect(304, function() {
+        expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
+          + ' ' + chalk.bold('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.cyan('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.gray('%s'),
+            'GET',
+            '/304',
+            304,
+            sinon.match.any,
+            '');
+        done();
+      });
+    });
+
+    it('should log a 404 response', function(done) {
+      request(app.listen()).get('/404').expect(404, function() {
+        expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
+          + ' ' + chalk.bold('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.yellow('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.gray('%s'),
+            'GET',
+            '/404',
+            404,
+            sinon.match.any,
+            '9b');
+        done();
+      });
+    });
+
+    it('should log a 500 response', function(done) {
+      request(app.listen()).get('/500').expect(500, function() {
+        expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
+          + ' ' + chalk.bold('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.red('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.gray('%s'),
+            'GET',
+            '/500',
+            500,
+            sinon.match.any,
+            '12b');
+        done();
+      });
+    });
+
+    it('should log middleware error', function(done) {
+      request(app.listen()).get('/error').expect(500, function() {
+        expect(log).to.have.been.calledWith('  ' + chalk.red('xxx')
+          + ' ' + chalk.bold('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.red('%s')
+          + ' ' + chalk.gray('%s')
+          + ' ' + chalk.gray('%s'),
+            'GET',
+            '/error',
+            500,
+            sinon.match.any,
+            '-');
+        done();
+      });
     });
   });
 
-  it('should log a request with correct method and url', function(done) {
-    request(app.listen()).head('/200').expect(200, function() {
-      expect(log).to.have.been.calledWith('  ' + chalk.gray('<--')
-        + ' ' + chalk.bold('%s')
-        + ' ' + chalk.gray('%s'),
+  describe('disableColor option', function() {
+    before(function() {
+      app = require('./test-server');
+      app.use(logger({ disableColor: true }));
+      app.init();
+    });
+
+    beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+      log = sandbox.spy(console, 'log');
+    });
+
+    afterEach(function() {
+      sandbox.restore();
+    });
+
+    it('should log response with no ansii color information', function(done) {
+      request(app.listen()).head('/200').expect(200, function() {
+        expect(log).to.have.been.calledWith(stripAnsi('  ' + chalk.gray('<--')
+          + ' ' + chalk.bold('%s')
+          + ' ' + chalk.gray('%s'),
           'HEAD',
-          '/200');
-      done();
-    });
-  });
-
-  it('should log a response', function(done) {
-    request(app.listen()).get('/200').expect(200, function() {
-      expect(log).to.have.been.calledTwice;
-      done();
-    });
-  });
-
-  it('should log a 200 response', function(done) {
-    request(app.listen()).get('/200').expect(200, function() {
-      expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
-        + ' ' + chalk.bold('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.green('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.gray('%s'),
-          'GET',
-          '/200',
-          200,
-          sinon.match.any,
-          '11b');
-      done();
-    });
-  });
-
-  it('should log a 301 response', function(done) {
-    request(app.listen()).get('/301').expect(301, function() {
-      expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
-        + ' ' + chalk.bold('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.cyan('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.gray('%s'),
-          'GET',
-          '/301',
-          301,
-          sinon.match.any,
-          '-');
-      done();
-    });
-  });
-
-  it('should log a 304 response', function(done) {
-    request(app.listen()).get('/304').expect(304, function() {
-      expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
-        + ' ' + chalk.bold('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.cyan('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.gray('%s'),
-          'GET',
-          '/304',
-          304,
-          sinon.match.any,
-          '');
-      done();
-    });
-  });
-
-  it('should log a 404 response', function(done) {
-    request(app.listen()).get('/404').expect(404, function() {
-      expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
-        + ' ' + chalk.bold('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.yellow('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.gray('%s'),
-          'GET',
-          '/404',
-          404,
-          sinon.match.any,
-          '9b');
-      done();
-    });
-  });
-
-  it('should log a 500 response', function(done) {
-    request(app.listen()).get('/500').expect(500, function() {
-      expect(log).to.have.been.calledWith('  ' + chalk.gray('-->')
-        + ' ' + chalk.bold('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.red('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.gray('%s'),
-          'GET',
-          '/500',
-          500,
-          sinon.match.any,
-          '12b');
-      done();
-    });
-  });
-
-  it('should log middleware error', function(done) {
-    request(app.listen()).get('/error').expect(500, function() {
-      expect(log).to.have.been.calledWith('  ' + chalk.red('xxx')
-        + ' ' + chalk.bold('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.red('%s')
-        + ' ' + chalk.gray('%s')
-        + ' ' + chalk.gray('%s'),
-          'GET',
-          '/error',
-          500,
-          sinon.match.any,
-          '-');
-      done();
-    });
+          '/200'));
+        done();
+      });
+    })
   });
 });


### PR DESCRIPTION
We use koa-logger for end-point logging, however in a production environment where we are logging to a file we do not want all the extraneous ansi color information. Allow for disabling of color output via options.