### PR TITLE
Updating README.md, Koa has a capital first letter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 [![npm version][npm-image]][npm-url]
 [![build status][travis-image]][travis-url]
 
- Development style logger middleware for [koa](https://github.com/koajs/koa).
+ Development style logger middleware for [Koa](https://github.com/koajs/koa).
 
 ```
 <-- GET /


### PR DESCRIPTION
Need to be consistent. For example https://github.com/koajs/compress has Koa capitalized. Main site also uses capital Koa.