### PR TITLE
Allow bytes package 2.x to be used

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ function log(ctx, start, len, err, event) {
   } else if (null == len) {
     length = '-';
   } else {
-    length = bytes(len);
+    length = bytes(len).toLowerCase();
   }
 
   const upstream = err ? chalk.red('xxx')

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "bytes": "1",
+    "bytes": ">=1.0.0 <3.0.0",
     "chalk": "^1.1.3",
     "humanize-number": "0.0.2",
     "passthrough-counter": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "bytes": ">=1.0.0 <3.0.0",
+    "bytes": "^2.0.0",
     "chalk": "^1.1.3",
     "humanize-number": "0.0.2",
     "passthrough-counter": "^1.0.0"


### PR DESCRIPTION
I took a conservative approach to allowing 2.x to be used. This would allow peer dependencies of 1.x to keep being used if they are, or upgrading to 2.x if that's what peers are using.

I'm equally fine with forcing 2.x to be used with the more traditional ^2.0.0 if that's preferred.