### PR TITLE
Require node 6 to match the koa 2.x dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "7"
 script: npm test

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "index.js"
   ],
   "scripts": {
-    "test": "mocha --harmony test.js"
+    "test": "mocha test.js"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -30,5 +30,8 @@
     "chalk": "^1.1.3",
     "humanize-number": "0.0.2",
     "passthrough-counter": "^1.0.0"
+  },
+  "engines": {
+    "node": ">= 6.0.0"
   }
 }


### PR DESCRIPTION
When submitting PR #56 I noticed that the Travis build failed due to a syntax error with node v4. Since this project depends on koa v2 and koa v2 depends on node >= 6 I figured it would make sense to restrict the allowed engines and the travis configuration to only test on >= 6.