### PR TITLE
Fixes error 'chalk[color] does not return function'

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = dev
  */
 
 const colorCodes = {
+  7: 'magenta',
   5: 'red',
   4: 'yellow',
   3: 'cyan',
@@ -91,7 +92,7 @@ function log (ctx, start, len, err, event) {
 
   // set the color of the status code;
   const s = status / 100 | 0
-  const color = colorCodes[s]
+  const color = colorCodes.hasOwnProperty(s) ? colorCodes[s] : 0
 
   // get the human readable response length
   let length


### PR DESCRIPTION
- Fixes error 'chalk[color] does not return function' when using custom status codes
- Adds magenta as official color for RFC 7xx HTTP Status Codes