### PR TITLE
add a transporter to logger opts param

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,6 +40,30 @@ app.use(logger())
   Recommended that you `.use()` this middleware near the top
   to "wrap" all subsequent middleware.
 
+## Use Custom Transporter
+
+```js
+const logger = require('koa-logger')
+const Koa = require('koa')
+
+const app = new Koa()
+app.use(logger((str, args) => {
+  // redirect koa logger to other output pipe
+  // default is process.stdout(by console.log function)
+}))
+```
+or
+```js
+app.use(logger({
+  transporter: (str, args) => {
+    // ...
+  }
+}))
+```
+
+  Param `str` is output string with ANSI Color, and you can get pure text with other modules like `strip-ansi`  
+  Param `args` is a array by `[format, method, url, status, time, length]`
+
 ## License
 
   MIT

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const colorCodes = {
 
 function dev (opts) {
   // print to console helper.
-  var print = function () {
+  var print = (function () {
     var transporter
     if (typeof opts === 'function') {
       transporter = opts
@@ -44,14 +44,14 @@ function dev (opts) {
     }
 
     return function printFunc (...args) {
-      var str = util.format(...args);
-      if(transporter) {
-        transporter(str, args);
-      }else {
-        console.log(...args);
+      var str = util.format(...args)
+      if (transporter) {
+        transporter(str, args)
+      } else {
+        console.log(...args)
       }
     }
-  }();
+  }())
 
   return async function logger (ctx, next) {
     // request

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const Counter = require('passthrough-counter')
 const humanize = require('humanize-number')
 const bytes = require('bytes')
 const chalk = require('chalk')
+const util = require('util')
 
 /**
  * Expose logger.
@@ -33,10 +34,29 @@ const colorCodes = {
  */
 
 function dev (opts) {
+  // print to console helper.
+  var print = function () {
+    var transporter
+    if (typeof opts === 'function') {
+      transporter = opts
+    } else if (!!opts && !!opts.transporter) {
+      transporter = opts.transporter
+    }
+
+    return function printFunc (...args) {
+      var str = util.format(...args);
+      if(transporter) {
+        transporter(str, args);
+      }else {
+        console.log(...args);
+      }
+    }
+  }();
+
   return async function logger (ctx, next) {
     // request
     const start = Date.now()
-    console.log('  ' + chalk.gray('<--') +
+    print('  ' + chalk.gray('<--') +
       ' ' + chalk.bold('%s') +
       ' ' + chalk.gray('%s'),
         ctx.method,
@@ -46,7 +66,7 @@ function dev (opts) {
       await next()
     } catch (err) {
       // log uncaught downstream errors
-      log(ctx, start, null, err)
+      log(print, ctx, start, null, err)
       throw err
     }
 
@@ -75,7 +95,7 @@ function dev (opts) {
     function done (event) {
       res.removeListener('finish', onfinish)
       res.removeListener('close', onclose)
-      log(ctx, start, counter ? counter.length : length, null, event)
+      log(print, ctx, start, counter ? counter.length : length, null, event)
     }
   }
 }
@@ -84,7 +104,7 @@ function dev (opts) {
  * Log helper.
  */
 
-function log (ctx, start, len, err, event) {
+function log (print, ctx, start, len, err, event) {
   // get the status code of the response
   const status = err
     ? (err.isBoom ? err.output.statusCode : err.status || 500)
@@ -108,7 +128,7 @@ function log (ctx, start, len, err, event) {
     : event === 'close' ? chalk.yellow('-x-')
     : chalk.gray('-->')
 
-  console.log('  ' + upstream +
+  print('  ' + upstream +
     ' ' + chalk.bold('%s') +
     ' ' + chalk.gray('%s') +
     ' ' + chalk[color]('%s') +

--- a/test-server.js
+++ b/test-server.js
@@ -8,37 +8,41 @@ const Boom = require('boom')
 const _ = require('koa-route')
 const logger = require('./index')
 
-const app = new Koa()
-app.use(logger())
+module.exports = function(opts) {
+  const app = new Koa()
+  app.use(logger(opts))
 
-app.use(_.get('/200', function (ctx) {
-  ctx.body = 'hello world'
-}))
+  app.use(_.get('/200', function (ctx) {
+    ctx.body = 'hello world'
+  }))
 
-app.use(_.get('/301', function (ctx) {
-  ctx.status = 301
-}))
+  app.use(_.get('/301', function (ctx) {
+    ctx.status = 301
+  }))
 
-app.use(_.get('/304', function (ctx) {
-  ctx.status = 304
-}))
+  app.use(_.get('/304', function (ctx) {
+    ctx.status = 304
+  }))
 
-app.use(_.get('/404', function (ctx) {
-  ctx.status = 404
-  ctx.body = 'not found'
-}))
+  app.use(_.get('/404', function (ctx) {
+    ctx.status = 404
+    ctx.body = 'not found'
+  }))
 
-app.use(_.get('/500', function (ctx) {
-  ctx.status = 500
-  ctx.body = 'server error'
-}))
+  app.use(_.get('/500', function (ctx) {
+    ctx.status = 500
+    ctx.body = 'server error'
+  }))
 
-app.use(_.get('/500-boom', function (ctx) {
-  ctx.throw(Boom.badImplementation('terrible implementation'))
-}))
+  app.use(_.get('/500-boom', function (ctx) {
+    ctx.throw(Boom.badImplementation('terrible implementation'))
+  }))
 
-app.use(_.get('/error', function (ctx) {
-  throw new Error('oh no')
-}))
+  app.use(_.get('/error', function (ctx) {
+    throw new Error('oh no')
+  }))
 
-module.exports = app
+  return app
+}
+
+// module.exports = app

--- a/test-server.js
+++ b/test-server.js
@@ -8,7 +8,7 @@ const Boom = require('boom')
 const _ = require('koa-route')
 const logger = require('./index')
 
-module.exports = function(opts) {
+module.exports = function (opts) {
   const app = new Koa()
   app.use(logger(opts))
 

--- a/test-server.js
+++ b/test-server.js
@@ -44,5 +44,3 @@ module.exports = function (opts) {
 
   return app
 }
-
-// module.exports = app

--- a/test.js
+++ b/test.js
@@ -13,19 +13,18 @@ const expect = chai.expect
 
 // test subjects
 const chalk = require('chalk')
-const util = require('util')
 
 let log, sandbox, transporter, app
 let transporterFunc = {
-  blankFunc: function(str, args) {
+  blankFunc: function (str, args) {
     // blankFunc
-  },
+  }
 }
 
 describe('koa-logger', function () {
-  before(function() {
+  before(function () {
     app = require('./test-server')()
-  });
+  })
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
@@ -181,17 +180,17 @@ describe('koa-logger', function () {
   })
 })
 
-describe('koa-logger-transporter-direct', function() {
-  before(function() {
-    transporter = function(str, args) {
+describe('koa-logger-transporter-direct', function () {
+  before(function () {
+    transporter = function (str, args) {
       transporterFunc.blankFunc(str, args)
-    };
+    }
     app = require('./test-server')(transporter)
-  });
+  })
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
-    log = sandbox.spy(transporterFunc, "blankFunc")
+    log = sandbox.spy(transporterFunc, 'blankFunc')
   })
 
   afterEach(function () {
@@ -210,8 +209,8 @@ describe('koa-logger-transporter-direct', function() {
       expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('<--') +
         ' ' + chalk.bold('%s') +
         ' ' + chalk.gray('%s'),
-          'HEAD',
-          '/200'])
+        'HEAD',
+        '/200'])
       done()
     })
   })
@@ -231,11 +230,11 @@ describe('koa-logger-transporter-direct', function() {
         ' ' + chalk.green('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/200',
-          200,
-          sinon.match.any,
-          '11b'])
+        'GET',
+        '/200',
+        200,
+        sinon.match.any,
+        '11b'])
       done()
     })
   })
@@ -248,11 +247,11 @@ describe('koa-logger-transporter-direct', function() {
         ' ' + chalk.cyan('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/301',
-          301,
-          sinon.match.any,
-          '-'])
+        'GET',
+        '/301',
+        301,
+        sinon.match.any,
+        '-'])
       done()
     })
   })
@@ -265,11 +264,11 @@ describe('koa-logger-transporter-direct', function() {
         ' ' + chalk.cyan('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/304',
-          304,
-          sinon.match.any,
-          ''])
+        'GET',
+        '/304',
+        304,
+        sinon.match.any,
+        ''])
       done()
     })
   })
@@ -282,11 +281,11 @@ describe('koa-logger-transporter-direct', function() {
         ' ' + chalk.yellow('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/404',
-          404,
-          sinon.match.any,
-          '9b'])
+        'GET',
+        '/404',
+        404,
+        sinon.match.any,
+        '9b'])
       done()
     })
   })
@@ -299,11 +298,11 @@ describe('koa-logger-transporter-direct', function() {
         ' ' + chalk.red('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/500',
-          500,
-          sinon.match.any,
-          '12b'])
+        'GET',
+        '/500',
+        500,
+        sinon.match.any,
+        '12b'])
       done()
     })
   })
@@ -316,11 +315,11 @@ describe('koa-logger-transporter-direct', function() {
         ' ' + chalk.red('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/error',
-          500,
-          sinon.match.any,
-          '-'])
+        'GET',
+        '/error',
+        500,
+        sinon.match.any,
+        '-'])
       done()
     })
   })
@@ -333,27 +332,27 @@ describe('koa-logger-transporter-direct', function() {
         ' ' + chalk.red('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/500-boom',
-          500,
-          sinon.match.any,
-          '-'])
+        'GET',
+        '/500-boom',
+        500,
+        sinon.match.any,
+        '-'])
       done()
     })
   })
 })
 
-describe('koa-logger-transporter-opts', function() {
-  before(function() {
-    transporter = function(str, args) {
+describe('koa-logger-transporter-opts', function () {
+  before(function () {
+    transporter = function (str, args) {
       transporterFunc.blankFunc(str, args)
-    };
+    }
     app = require('./test-server')({transporter})
-  });
+  })
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
-    log = sandbox.spy(transporterFunc, "blankFunc")
+    log = sandbox.spy(transporterFunc, 'blankFunc')
   })
 
   afterEach(function () {
@@ -372,8 +371,8 @@ describe('koa-logger-transporter-opts', function() {
       expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('<--') +
         ' ' + chalk.bold('%s') +
         ' ' + chalk.gray('%s'),
-          'HEAD',
-          '/200'])
+        'HEAD',
+        '/200'])
       done()
     })
   })
@@ -393,11 +392,11 @@ describe('koa-logger-transporter-opts', function() {
         ' ' + chalk.green('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/200',
-          200,
-          sinon.match.any,
-          '11b'])
+        'GET',
+        '/200',
+        200,
+        sinon.match.any,
+        '11b'])
       done()
     })
   })
@@ -410,11 +409,11 @@ describe('koa-logger-transporter-opts', function() {
         ' ' + chalk.cyan('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/301',
-          301,
-          sinon.match.any,
-          '-'])
+        'GET',
+        '/301',
+        301,
+        sinon.match.any,
+        '-'])
       done()
     })
   })
@@ -427,11 +426,11 @@ describe('koa-logger-transporter-opts', function() {
         ' ' + chalk.cyan('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/304',
-          304,
-          sinon.match.any,
-          ''])
+        'GET',
+        '/304',
+        304,
+        sinon.match.any,
+        ''])
       done()
     })
   })
@@ -444,11 +443,11 @@ describe('koa-logger-transporter-opts', function() {
         ' ' + chalk.yellow('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/404',
-          404,
-          sinon.match.any,
-          '9b'])
+        'GET',
+        '/404',
+        404,
+        sinon.match.any,
+        '9b'])
       done()
     })
   })
@@ -461,11 +460,11 @@ describe('koa-logger-transporter-opts', function() {
         ' ' + chalk.red('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/500',
-          500,
-          sinon.match.any,
-          '12b'])
+        'GET',
+        '/500',
+        500,
+        sinon.match.any,
+        '12b'])
       done()
     })
   })
@@ -478,11 +477,11 @@ describe('koa-logger-transporter-opts', function() {
         ' ' + chalk.red('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/error',
-          500,
-          sinon.match.any,
-          '-'])
+        'GET',
+        '/error',
+        500,
+        sinon.match.any,
+        '-'])
       done()
     })
   })
@@ -495,11 +494,11 @@ describe('koa-logger-transporter-opts', function() {
         ' ' + chalk.red('%s') +
         ' ' + chalk.gray('%s') +
         ' ' + chalk.gray('%s'),
-          'GET',
-          '/500-boom',
-          500,
-          sinon.match.any,
-          '-'])
+        'GET',
+        '/500-boom',
+        500,
+        sinon.match.any,
+        '-'])
       done()
     })
   })

--- a/test.js
+++ b/test.js
@@ -13,10 +13,20 @@ const expect = chai.expect
 
 // test subjects
 const chalk = require('chalk')
-const app = require('./test-server')
-let log, sandbox
+const util = require('util')
+
+let log, sandbox, transporter, app
+let transporterFunc = {
+  blankFunc: function(str, args) {
+    // blankFunc
+  },
+}
 
 describe('koa-logger', function () {
+  before(function() {
+    app = require('./test-server')()
+  });
+
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
     log = sandbox.spy(console, 'log')
@@ -166,6 +176,330 @@ describe('koa-logger', function () {
           500,
           sinon.match.any,
           '-')
+      done()
+    })
+  })
+})
+
+describe('koa-logger-transporter-direct', function() {
+  before(function() {
+    transporter = function(str, args) {
+      transporterFunc.blankFunc(str, args)
+    };
+    app = require('./test-server')(transporter)
+  });
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    log = sandbox.spy(transporterFunc, "blankFunc")
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('should log a request', function (done) {
+    request(app.listen()).get('/200').expect(200, 'hello world', function () {
+      expect(log).to.have.been.called // eslint-disable-line
+      done()
+    })
+  })
+
+  it('should log a request with correct method and url', function (done) {
+    request(app.listen()).head('/200').expect(200, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('<--') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s'),
+          'HEAD',
+          '/200'])
+      done()
+    })
+  })
+
+  it('should log a response', function (done) {
+    request(app.listen()).get('/200').expect(200, function () {
+      expect(log).to.have.been.calledTwice // eslint-disable-line
+      done()
+    })
+  })
+
+  it('should log a 200 response', function (done) {
+    request(app.listen()).get('/200').expect(200, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('-->') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.green('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/200',
+          200,
+          sinon.match.any,
+          '11b'])
+      done()
+    })
+  })
+
+  it('should log a 301 response', function (done) {
+    request(app.listen()).get('/301').expect(301, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('-->') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.cyan('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/301',
+          301,
+          sinon.match.any,
+          '-'])
+      done()
+    })
+  })
+
+  it('should log a 304 response', function (done) {
+    request(app.listen()).get('/304').expect(304, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('-->') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.cyan('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/304',
+          304,
+          sinon.match.any,
+          ''])
+      done()
+    })
+  })
+
+  it('should log a 404 response', function (done) {
+    request(app.listen()).get('/404').expect(404, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('-->') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.yellow('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/404',
+          404,
+          sinon.match.any,
+          '9b'])
+      done()
+    })
+  })
+
+  it('should log a 500 response', function (done) {
+    request(app.listen()).get('/500').expect(500, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('-->') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.red('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/500',
+          500,
+          sinon.match.any,
+          '12b'])
+      done()
+    })
+  })
+
+  it('should log middleware error', function (done) {
+    request(app.listen()).get('/error').expect(500, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.red('xxx') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.red('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/error',
+          500,
+          sinon.match.any,
+          '-'])
+      done()
+    })
+  })
+
+  it('should log a 500 response with boom', function (done) {
+    request(app.listen()).get('/500-boom').expect(500, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.red('xxx') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.red('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/500-boom',
+          500,
+          sinon.match.any,
+          '-'])
+      done()
+    })
+  })
+})
+
+describe('koa-logger-transporter-opts', function() {
+  before(function() {
+    transporter = function(str, args) {
+      transporterFunc.blankFunc(str, args)
+    };
+    app = require('./test-server')({transporter})
+  });
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    log = sandbox.spy(transporterFunc, "blankFunc")
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  it('should log a request', function (done) {
+    request(app.listen()).get('/200').expect(200, 'hello world', function () {
+      expect(log).to.have.been.called // eslint-disable-line
+      done()
+    })
+  })
+
+  it('should log a request with correct method and url', function (done) {
+    request(app.listen()).head('/200').expect(200, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('<--') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s'),
+          'HEAD',
+          '/200'])
+      done()
+    })
+  })
+
+  it('should log a response', function (done) {
+    request(app.listen()).get('/200').expect(200, function () {
+      expect(log).to.have.been.calledTwice // eslint-disable-line
+      done()
+    })
+  })
+
+  it('should log a 200 response', function (done) {
+    request(app.listen()).get('/200').expect(200, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('-->') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.green('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/200',
+          200,
+          sinon.match.any,
+          '11b'])
+      done()
+    })
+  })
+
+  it('should log a 301 response', function (done) {
+    request(app.listen()).get('/301').expect(301, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('-->') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.cyan('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/301',
+          301,
+          sinon.match.any,
+          '-'])
+      done()
+    })
+  })
+
+  it('should log a 304 response', function (done) {
+    request(app.listen()).get('/304').expect(304, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('-->') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.cyan('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/304',
+          304,
+          sinon.match.any,
+          ''])
+      done()
+    })
+  })
+
+  it('should log a 404 response', function (done) {
+    request(app.listen()).get('/404').expect(404, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('-->') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.yellow('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/404',
+          404,
+          sinon.match.any,
+          '9b'])
+      done()
+    })
+  })
+
+  it('should log a 500 response', function (done) {
+    request(app.listen()).get('/500').expect(500, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.gray('-->') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.red('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/500',
+          500,
+          sinon.match.any,
+          '12b'])
+      done()
+    })
+  })
+
+  it('should log middleware error', function (done) {
+    request(app.listen()).get('/error').expect(500, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.red('xxx') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.red('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/error',
+          500,
+          sinon.match.any,
+          '-'])
+      done()
+    })
+  })
+
+  it('should log a 500 response with boom', function (done) {
+    request(app.listen()).get('/500-boom').expect(500, function () {
+      expect(log).to.have.been.calledWith(sinon.match.string, ['  ' + chalk.red('xxx') +
+        ' ' + chalk.bold('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.red('%s') +
+        ' ' + chalk.gray('%s') +
+        ' ' + chalk.gray('%s'),
+          'GET',
+          '/500-boom',
+          500,
+          sinon.match.any,
+          '-'])
       done()
     })
   })


### PR DESCRIPTION
A function to redirect output string. To help use other log display like `debug` module, file storage, add prefix or suffix, and custom.  
Related Issue: #31 
use like this:
```js
app.use(logger((str) => console.log("access log:" + str)))
```
or
```js
app.use(logger({
  transporter: (str) => console.log("access log:" + str)
}))
```

This pull request contains full function implement, test case and readme file.  
Thanks for review