### PR TITLE
Fixed error when using custom error codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function log (print, ctx, start, len, err, event) {
 
   // set the color of the status code;
   const s = status / 100 | 0
-  const color = colorCodes.hasOwnProperty(s) ? colorCodes[s] : 0
+  const color = colorCodes.hasOwnProperty(s) ? colorCodes[s] : colorCodes[0]
 
   // get the human readable response length
   let length


### PR DESCRIPTION
Fixed error when using custom error codes > 800. The default color at index 0 is used by default.

Fixes #72 