### PR TITLE
Register response event listener earlier

### DIFF
--- a/test.js
+++ b/test.js
@@ -89,7 +89,7 @@ describe('koa-logger', function () {
           '/301',
           301,
           sinon.match.any,
-          '-')
+          '17b')
       done()
     })
   })
@@ -251,7 +251,7 @@ describe('koa-logger-transporter-direct', function () {
         '/301',
         301,
         sinon.match.any,
-        '-'])
+        '17b'])
       done()
     })
   })
@@ -413,7 +413,7 @@ describe('koa-logger-transporter-opts', function () {
         '/301',
         301,
         sinon.match.any,
-        '-'])
+        '17b'])
       done()
     })
   })


### PR DESCRIPTION
In some cases, the response may be terminated by a upstream middleware, which causes `finish` or `close` events to be triggered even before handlers are registered. (e.g. a client is trying to send a huge amount of data through stream, but the server decided not to read it and closed the stream).

When this happens, we are still expecting to see a log which shows the connection is broken.

This can be done by registering the event listeners before calling `next`.