### PR TITLE
Pass ctx to transporter

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,9 @@ module.exports = function (options) {
     }
 
     // eslint-disable-next-line func-names
-    return function printFunc(...args) {
+    return function printFunc(ctx, ...args) {
       const string = util.format(...args);
-      if (transporter) transporter(string, args);
+      if (transporter) transporter(string, args, ctx);
       else console.log(...args);
     };
   })();
@@ -42,6 +42,7 @@ module.exports = function (options) {
       ? ctx[Symbol.for('request-received.startTime')].getTime()
       : Date.now();
     print(
+      ctx,
       '  ' +
         chalk.gray('<--') +
         ' ' +
@@ -116,6 +117,7 @@ function log(print, ctx, start, length_, err, event) {
     : chalk.gray('-->');
 
   print(
+    ctx,
     '  ' +
       upstream +
       ' ' +


### PR DESCRIPTION
Enables more verbose Transporter to log other ctx details. Fixes issues #77 and #82.

`ctx` is passed as the 3rd argument to transporter as to not disrupt any existing code. That said, it could easily be the first argument if desired.
```
app.use(logger((str, args, ctx) => {
  console.log(str, ctx.request.ip); // ctx.request.header['user-agent'], etc...
}))
```