### PR TITLE
Fix streaming body sizes not being logged

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const counterFunc = require('passthrough-counter');
+const Counter = require('passthrough-counter');
 const humanize = require('humanize-number');
 const bytes = require('bytes');
 const chalk = require('chalk');
@@ -68,8 +68,8 @@ module.exports = function (options) {
       response: { length }
     } = ctx;
     let counter;
-    if (length === null && body && body.readable)
-      ctx.body = body.pipe((counter = counterFunc())).on('error', ctx.onerror);
+    if (length == null && body && body.readable)
+      counter = body.pipe(new Counter()).on('error', ctx.onerror);
 
     // log when the response is finished or closed,
     // whichever happens first.

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -1,6 +1,7 @@
 const Koa = require('koa');
 const Boom = require('boom');
 const _ = require('koa-route');
+const { Readable } = require('stream');
 const logger = require('..');
 
 module.exports = function (options) {
@@ -10,6 +11,12 @@ module.exports = function (options) {
   app.use(
     _.get('/200', function (ctx) {
       ctx.body = 'hello world';
+    })
+  );
+
+  app.use(
+    _.get('/200-stream', function (ctx) {
+      ctx.body = Readable.from(['hello world']);
     })
   );
 

--- a/test/test.js
+++ b/test/test.js
@@ -98,8 +98,6 @@ describe('koa-logger', function () {
       });
   });
 
-  
-
   it('should log a 200 response for stream', function (done) {
     request(app.listen())
       .get('/200-stream')

--- a/test/test.js
+++ b/test/test.js
@@ -98,6 +98,35 @@ describe('koa-logger', function () {
       });
   });
 
+  
+
+  it('should log a 200 response for stream', function (done) {
+    request(app.listen())
+      .get('/200-stream')
+      .expect(200, function () {
+        expect(log).to.have.been.calledWith(
+          '  ' +
+            chalk.gray('-->') +
+            ' ' +
+            chalk.bold('%s') +
+            ' ' +
+            chalk.gray('%s') +
+            ' ' +
+            chalk.green('%s') +
+            ' ' +
+            chalk.gray('%s') +
+            ' ' +
+            chalk.gray('%s'),
+          'GET',
+          '/200-stream',
+          200,
+          sinon.match.any,
+          '11b'
+        );
+        done();
+      });
+  });
+
   it('should log a 301 response', function (done) {
     request(app.listen())
       .get('/301')


### PR DESCRIPTION
I noticed that the size of streamed bodies weren't being logged. I went to poke around and noticed that none of the tests for logger were checking streams. I added a test and it failed. It seems that the problem was that `ctx.response.length` was resolving to `undefined` which means that `length === null` is `false` and so it doesn't add the counter to the stream. I changed that line from a strict `null` check to a nullish check and it seems to be working.