### PR TITLE
Fix untracked body

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const counterFunc = require('passthrough-counter');
+const Counter = require('passthrough-counter');
 const humanize = require('humanize-number');
 const bytes = require('bytes');
 const chalk = require('chalk');
@@ -68,8 +68,8 @@ module.exports = function (options) {
       response: { length }
     } = ctx;
     let counter;
-    if (length === null && body && body.readable)
-      ctx.body = body.pipe((counter = counterFunc())).on('error', ctx.onerror);
+    if (length == null && body && body.readable)
+      counter = body.pipe(new Counter()).on('error', ctx.onerror);
 
     // log when the response is finished or closed,
     // whichever happens first.

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -1,6 +1,7 @@
 const Koa = require('koa');
 const Boom = require('boom');
 const _ = require('koa-route');
+const { Readable } = require('stream');
 const logger = require('..');
 
 module.exports = function (options) {
@@ -10,6 +11,12 @@ module.exports = function (options) {
   app.use(
     _.get('/200', function (ctx) {
       ctx.body = 'hello world';
+    })
+  );
+
+  app.use(
+    _.get('/200-stream', function (ctx) {
+      ctx.body = Readable.from(['hello world']);
     })
   );
 

--- a/test/test.js
+++ b/test/test.js
@@ -146,7 +146,7 @@ describe('koa-logger', function () {
           '/301',
           301,
           sinon.match.any,
-          '-'
+          '17b'
         );
         done();
       });
@@ -390,7 +390,7 @@ describe('koa-logger-transporter-direct', function () {
           '/301',
           301,
           sinon.match.any,
-          '-'
+          '17b'
         ]);
         done();
       });
@@ -634,7 +634,7 @@ describe('koa-logger-transporter-opts', function () {
           '/301',
           301,
           sinon.match.any,
-          '-'
+          '17b'
         ]);
         done();
       });

--- a/test/test.js
+++ b/test/test.js
@@ -98,8 +98,6 @@ describe('koa-logger', function () {
       });
   });
 
-  
-
   it('should log a 200 response for stream', function (done) {
     request(app.listen())
       .get('/200-stream')

--- a/test/test.js
+++ b/test/test.js
@@ -98,6 +98,35 @@ describe('koa-logger', function () {
       });
   });
 
+  
+
+  it('should log a 200 response for stream', function (done) {
+    request(app.listen())
+      .get('/200-stream')
+      .expect(200, function () {
+        expect(log).to.have.been.calledWith(
+          '  ' +
+            chalk.gray('-->') +
+            ' ' +
+            chalk.bold('%s') +
+            ' ' +
+            chalk.gray('%s') +
+            ' ' +
+            chalk.green('%s') +
+            ' ' +
+            chalk.gray('%s') +
+            ' ' +
+            chalk.gray('%s'),
+          'GET',
+          '/200-stream',
+          200,
+          sinon.match.any,
+          '11b'
+        );
+        done();
+      });
+  });
+
   it('should log a 301 response', function (done) {
     request(app.listen())
       .get('/301')


### PR DESCRIPTION
This PR is based on #86.

Currently there seems to be an assumption that the body will not be modified upstream. This might be intended but, as it is, if koa (or any other upstream middleware) sets the body after the logger finishes, that change will not be reflected in the logged bytes sent.

Even if koa is the only thing upstream, it currently sets a body if none is provided for certain status codes. For example, if the only thing you do is set `ctx.status` to 301, koa will add a body of `Moved Permanently` after all middleware.

The current implementation uses the value in the `Content-Length` header after all downstream middleware have finished as the number of bytes sent.
This PR changes this so that it uses the value of the `Content-Length` header after the response has been sent/closes. This happens to also be when the actual `console.log` occurs.

This doesn't impact the behavior if the body is a stream. It also doesn't change anything if the length is nullish.
